### PR TITLE
Update to nodejs 24

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup .NET
         id: dotnet
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
       - name: Build

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Setup .NET
         id: dotnet
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Generate Release Notes
         id: release_notes
-        uses: Fresa/release-notes-generator@v4.0.0
+        uses: Fresa/release-notes-generator@v4
         with:
           version: ${{ steps.release-tag.outputs.tag }}
           last_release_ref: ${{ steps.versioning.outputs.last-release-ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Generate Release Notes
         id: release_notes
-        uses: Fresa/release-notes-generator@v4.0.0-pre-4a67018b
+        uses: Fresa/release-notes-generator@v4.0.0
         with:
           version: ${{ steps.release-tag.outputs.tag }}
           last_release_ref: ${{ steps.versioning.outputs.last-release-ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
       # Create release and tags
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Fetches entire history, so we can analyze commits since last tag
           fetch-depth: 0
@@ -82,7 +82,7 @@ jobs:
 
       - name: Generate Release Notes
         id: release_notes
-        uses: Fresa/release-notes-generator@v3
+        uses: Fresa/release-notes-generator@v4.0.0-pre-4a67018b
         with:
           version: ${{ steps.release-tag.outputs.tag }}
           last_release_ref: ${{ steps.versioning.outputs.last-release-ref }}
@@ -94,7 +94,7 @@ jobs:
           echo "${{ steps.release_notes.outputs.release_notes }}" > "${{ inputs.project_path }}/release_notes.txt"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
 
@@ -116,7 +116,7 @@ jobs:
             -p:ContinuousIntegrationBuild=true
 
       - name: Create Tag
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             try {

--- a/.gitignore
+++ b/.gitignore
@@ -397,3 +397,4 @@ FodyWeavers.xsd
 # JetBrains Rider
 *.sln.iml
 .idea/*
+.claude/


### PR DESCRIPTION
Upgrades all actions to Node.js 24 runtime supported versions for the release library reusable workflow. Make sure to use a github action runner with Node.js 24 installed.